### PR TITLE
feat: standard jwt generate/extract + ExtractClient + rest id to array + rest id recursive validator

### DIFF
--- a/crypto/go.mod
+++ b/crypto/go.mod
@@ -2,4 +2,8 @@ module github.com/forkyid/go-utils/crypto
 
 go 1.14
 
-require github.com/speps/go-hashids v2.0.0+incompatible
+require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/forkyid/go-utils/rest v0.0.0-20200704062648-3f28f0102baf // indirect
+	github.com/speps/go-hashids v2.0.0+incompatible
+)

--- a/crypto/jwt/constants.go
+++ b/crypto/jwt/constants.go
@@ -1,0 +1,7 @@
+package jwt
+
+const (
+	AppName                   = "FORKY.ID (PT. SUPER GIGA GENERASI)"
+	AccessTokenDurationMinute = (60 * 24 * 30)
+	RefreshTokenDurationHour  = 24 * 30
+)

--- a/crypto/jwt/entity.go
+++ b/crypto/jwt/entity.go
@@ -1,0 +1,15 @@
+package jwt
+
+import (
+	"github.com/dgrijalva/jwt-go"
+	"github.com/forkyid/go-utils/rest/restid"
+)
+
+// Claims claims
+type Claims struct {
+	jwt.StandardClaims
+	MemberID       restid.ID `json:"id"`
+	RoleID         restid.ID `json:"role_id"`
+	MemberUsername string    `json:"username"`
+	Type           string    `json:"type"`
+}

--- a/crypto/jwt/extract.go
+++ b/crypto/jwt/extract.go
@@ -1,0 +1,73 @@
+package jwt
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"os"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/forkyid/service-cms-member/src/util/helper/crypto/aes"
+)
+
+// ExtractClaims extracts claims from JWT, returns claims as map
+func ExtractClaims(tokenStr string) (jwt.MapClaims, bool) {
+	hmacSecretString := os.Getenv("JWT_ACCESS_SIGNATURE_KEY")
+	hmacSecret := []byte(hmacSecretString)
+	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
+		// check token signing method etc
+		return hmacSecret, nil
+	})
+
+	if err != nil {
+		log.Println(err.Error())
+		return nil, false
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		log.Println("Invalid JWT Token")
+		return nil, false
+	}
+
+	return claims, true
+}
+
+// ExtractID extracts only the id from JWT
+func ExtractID(ah string) (int, error) {
+	ts := strings.Replace(ah, "Bearer ", "", -1)
+	claimsMap, claimRes := ExtractClaims(ts)
+	if !claimRes {
+		return -1, fmt.Errorf("Failed on claiming token")
+	}
+	id := aes.Decrypt(claimsMap["id"].(string))
+	if id == -1 {
+		return -1, fmt.Errorf("Invalid ID")
+	}
+	return id, nil
+}
+
+// ExtractClient extracts only the id from JWT
+func ExtractClient(ah string) (*Claims, error) {
+	ts := strings.Replace(ah, "Bearer ", "", -1)
+	claims := Claims{}
+
+	claimsMap, claimRes := ExtractClaims(ts)
+	if !claimRes {
+		return nil, fmt.Errorf("Failed on claiming token")
+	}
+
+	j, err := json.Marshal(&claimsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(j, &claims)
+	if err != nil {
+		return nil, err
+	}
+
+	return &claims, nil
+}

--- a/crypto/jwt/generate.go
+++ b/crypto/jwt/generate.go
@@ -1,0 +1,72 @@
+package jwt
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/forkyid/go-utils/rest/restid"
+)
+
+var applicationName = AppName
+var accessExpirationDuration = time.Duration(AccessTokenDurationMinute) * time.Minute
+var refreshExpirationDuration = time.Duration(RefreshTokenDurationHour) * time.Hour
+var jwtSigningMethod = jwt.SigningMethodHS256
+
+// GenerateAccessToken params
+// @memberID: string
+// @username: string
+// return error, string
+func GenerateAccessToken(memberID, roleID restid.ID, username string) (string, error) {
+
+	claims := Claims{
+		StandardClaims: jwt.StandardClaims{
+			Issuer:    applicationName,
+			ExpiresAt: time.Now().Add(accessExpirationDuration).Unix(),
+		},
+		MemberID:       memberID,
+		MemberUsername: username,
+		RoleID:         roleID,
+		Type:           "Access-Token",
+	}
+
+	token := jwt.NewWithClaims(jwtSigningMethod, claims)
+
+	signedToken, err := token.SignedString([]byte(os.Getenv("JWT_ACCESS_SIGNATURE_KEY")))
+	if err != nil {
+		return "", errors.New("token signing error")
+	}
+
+	return signedToken, nil
+}
+
+// GenerateRefreshToken params
+// @memberID: string
+// @username: string
+// return error, string
+func GenerateRefreshToken(memberID, roleID restid.ID, username string) (string, error) {
+
+	claims := Claims{
+		StandardClaims: jwt.StandardClaims{
+			Issuer:    applicationName,
+			ExpiresAt: time.Now().Add(refreshExpirationDuration).Unix(),
+		},
+		MemberID:       memberID,
+		MemberUsername: username,
+		RoleID:         roleID,
+		Type:           "Refresh-Token",
+	}
+
+	token := jwt.NewWithClaims(
+		jwtSigningMethod,
+		claims,
+	)
+
+	signedToken, err := token.SignedString([]byte(os.Getenv("JWT_REFRESH_SIGNATURE_KEY")))
+	if err != nil {
+		return "", errors.New("token signing error")
+	}
+
+	return signedToken, nil
+}

--- a/crypto/jwt/generate.go
+++ b/crypto/jwt/generate.go
@@ -9,7 +9,6 @@ import (
 	"github.com/forkyid/go-utils/rest/restid"
 )
 
-var applicationName = AppName
 var accessExpirationDuration = time.Duration(AccessTokenDurationMinute) * time.Minute
 var refreshExpirationDuration = time.Duration(RefreshTokenDurationHour) * time.Hour
 var jwtSigningMethod = jwt.SigningMethodHS256
@@ -19,7 +18,10 @@ var jwtSigningMethod = jwt.SigningMethodHS256
 // @username: string
 // return error, string
 func GenerateAccessToken(memberID, roleID restid.ID, username string) (string, error) {
-
+	applicationName := os.Getenv("APPLICATION_NAME")
+	if applicationName == "" {
+		applicationName = AppName
+	}
 	claims := Claims{
 		StandardClaims: jwt.StandardClaims{
 			Issuer:    applicationName,
@@ -46,7 +48,10 @@ func GenerateAccessToken(memberID, roleID restid.ID, username string) (string, e
 // @username: string
 // return error, string
 func GenerateRefreshToken(memberID, roleID restid.ID, username string) (string, error) {
-
+	applicationName := os.Getenv("APPLICATION_NAME")
+	if applicationName == "" {
+		applicationName = AppName
+	}
 	claims := Claims{
 		StandardClaims: jwt.StandardClaims{
 			Issuer:    applicationName,

--- a/rest/restid/restid.go
+++ b/rest/restid/restid.go
@@ -86,3 +86,21 @@ func IDFromEncrypted(encrypted string) (id ID) {
 	}
 	return id
 }
+
+// ArrayToRaw return raw id array
+func ArrayToRaw(ids *[]ID) *[]uint {
+	raws := make([]uint, len(*ids))
+	for i := range *ids {
+		raws[i] = (*ids)[i].Raw
+	}
+	return &raws
+}
+
+// ArrayToEncrypted return encrypted id array
+func ArrayToEncrypted(ids *[]ID) *[]string {
+	encypteds := make([]string, len(*ids))
+	for i := range *ids {
+		encypteds[i] = (*ids)[i].Encrypted
+	}
+	return &encypteds
+}

--- a/validation/readme.md
+++ b/validation/readme.md
@@ -4,7 +4,7 @@ Makes use of four field tags: `validate`, `id`, `process`, `json`
 
 `validate` tags is passed to go-validator. Errors from go-validator is parsed into validation.ErrorDetails.
 
-`"id"` tags has three possible values: `"required"`, `"valid"` and `"allow-zero"`. `"required"` validates that the field is not empty, and is valid, sets the status code to 400 when empty and 422 when invalid. `"valid"` behaves similarly to `"required"` but returns 200 when empty. `"allow-zero"` allows zero value in id. When used on a slice, the tags will be applied to each element.
+`"id"` tags has three possible values: `"required"`, `"valid"`, `"allow-zero"`, and `"dive"`. `"required"` validates that the field is not empty, and is valid, sets the status code to 400 when empty and 422 when invalid. `"valid"` behaves similarly to `"required"` but returns 200 when empty. `"allow-zero"` allows zero value in id. When used on a slice, the tags will be applied to each element. Using the `"dive"` tag instructs the validator to recursively dive into slices, maps, and structs. The validator then checks for other tags within the slice/map/struct.
 
 `"process"` behaves in the same way as validate but returns 422 on error.
 

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -24,13 +24,13 @@ var Validator = func() *validator.Validate {
 	return v
 }()
 
-func validateID(details *rest.ErrorDetails, id restid.ID, name string, tags []string) (code int) {
+func validateID(details *rest.ErrorDetails, id *restid.ID, name string, tags []string) (code int) {
 	code = http.StatusOK
 	allowZero := false
 	for i := range tags {
 		switch tags[i] {
 		case "required":
-			if id.Encrypted == "" {
+			if id == nil || (*id).Encrypted == "" {
 				details.Add(name, "required")
 				if code != http.StatusBadRequest {
 					code = http.StatusBadRequest
@@ -38,7 +38,7 @@ func validateID(details *rest.ErrorDetails, id restid.ID, name string, tags []st
 				break
 			}
 
-			if !id.Valid {
+			if !(*id).Valid {
 				details.Add(name, "invalid")
 				if code != http.StatusBadRequest {
 					code = http.StatusUnprocessableEntity
@@ -47,7 +47,7 @@ func validateID(details *rest.ErrorDetails, id restid.ID, name string, tags []st
 			break
 
 		case "valid":
-			if id.Encrypted != "" && !id.Valid {
+			if id == nil || (*id).Encrypted != "" && !(*id).Valid {
 				details.Add(name, "invalid")
 				if code != http.StatusBadRequest {
 					code = http.StatusUnprocessableEntity
@@ -61,7 +61,7 @@ func validateID(details *rest.ErrorDetails, id restid.ID, name string, tags []st
 		}
 	}
 
-	if !allowZero && id.Valid && id.Raw == 0 {
+	if !allowZero && id != nil && (*id).Valid && (*id).Raw == 0 {
 		details.Add(name, "invalid")
 		if code != http.StatusBadRequest {
 			code = http.StatusUnprocessableEntity
@@ -83,38 +83,75 @@ func validateStructID(data interface{}) (details *rest.ErrorDetails, code int) {
 		field := v.Field(i)
 		fieldT := t.Field(i)
 
-		if field.Type().ConvertibleTo(reflect.TypeOf(id)) {
-			name := strings.SplitN(fieldT.Tag.Get("json"), ",", 2)[0]
-			if name == "" || name == "-" {
-				name = strings.ToLower(fieldT.Name)
-			}
+		name := strings.SplitN(fieldT.Tag.Get("json"), ",", 2)[0]
+		if name == "" || name == "-" {
+			name = strings.ToLower(fieldT.Name)
+		}
 
-			tags := strings.Split(fieldT.Tag.Get("id"), ",")
-			id = field.Interface().(restid.ID)
+		tags := strings.Split(fieldT.Tag.Get("id"), ",")
 
-			vCode := validateID(details, id, name, tags)
-			if vCode != http.StatusOK && code != http.StatusBadRequest {
-				code = vCode
-			}
+		if len(tags) <= 0 {
 			continue
 		}
 
-		if field.Type().ConvertibleTo(reflect.TypeOf([]restid.ID{})) {
-			name := strings.SplitN(fieldT.Tag.Get("json"), ",", 2)[0]
-			if name == "" || name == "-" {
-				name = strings.ToLower(fieldT.Name)
-			}
-
-			tags := strings.Split(fieldT.Tag.Get("id"), ",")
-			ids := field.Interface().([]restid.ID)
-
-			for i := range ids {
-				vCode := validateID(details, ids[i], fmt.Sprintf("%v[%v]", name, i), tags)
-				if vCode != http.StatusOK && code != http.StatusBadRequest {
-					code = vCode
+		vCode := http.StatusOK
+		switch field.Interface().(type) {
+		case *restid.ID, nil:
+			id := field.Interface().(*restid.ID)
+			vCode = validateID(details, id, name, tags)
+		case restid.ID:
+			id = field.Interface().(restid.ID)
+			vCode = validateID(details, &id, name, tags)
+		case string:
+			id = restid.IDFromEncrypted(field.Interface().(string))
+			vCode = validateID(details, &id, name, tags)
+		}
+		if tags[0] == "dive" {
+			switch field.Interface().(type) {
+			case *[]restid.ID:
+				ids := field.Interface().(*[]restid.ID)
+				for i := range *ids {
+					vCodei := validateID(details, &(*ids)[i], fmt.Sprintf("%v[%v]", name, i), tags)
+					if vCode != http.StatusOK && vCode != http.StatusBadRequest {
+						vCode = vCodei
+					}
+				}
+			case []restid.ID:
+				ids := field.Interface().([]restid.ID)
+				for i := range ids {
+					vCodei := validateID(details, &ids[i], fmt.Sprintf("%v[%v]", name, i), tags)
+					if vCode != http.StatusOK && code != http.StatusBadRequest {
+						vCode = vCodei
+					}
+				}
+			case map[restid.ID]interface{}:
+				ids := field.Interface().(map[restid.ID]interface{})
+				for id := range ids {
+					vCodei := validateID(details, &id, fmt.Sprintf("%v[%v]", name, id), tags)
+					if vCode != http.StatusOK && code != http.StatusBadRequest {
+						vCode = vCodei
+					}
+				}
+			case interface{}:
+				if field.Kind() == reflect.Slice {
+					for i := 0; i < field.Len(); i++ {
+						vDet, vCodei := validateStructID(field.Index(i).Interface())
+						vCode = vCodei
+						for k, v := range *vDet {
+							details.Add(fmt.Sprintf("%v[%v].%v", name, i, k), v)
+						}
+					}
+					break
+				}
+				vDet, vCodei := validateStructID(field.Interface())
+				vCode = vCodei
+				for k, v := range *vDet {
+					details.Add(name+"."+k, v)
 				}
 			}
-			continue
+		}
+		if vCode != http.StatusOK && code != http.StatusBadRequest {
+			code = vCode
 		}
 	}
 
@@ -158,10 +195,12 @@ func Validate(data interface{}) (details *rest.ErrorDetails, code int) {
 
 	err := Validator.Struct(data)
 	if err != nil {
-		for _, err := range err.(validator.ValidationErrors) {
-			details.Add(err.Field(), err.Tag())
+		if errV, ok := err.(validator.ValidationErrors); ok {
+			for _, err := range errV {
+				details.Add(err.Field(), err.Tag())
+			}
+			code = http.StatusBadRequest
 		}
-		code = http.StatusBadRequest
 	}
 
 	idDet, idCode := validateStructID(data)


### PR DESCRIPTION
- ExtractClient was added to extract the newly added "roles" claims in JWT (for cms) more easily
- added helper functions to convert rest id array to raw/encrypted array
- added new tag `"dive"` to id validator. allows recursive validation of slices, maps, and structs