### PR TITLE
Refactor

### DIFF
--- a/aes/aes.go
+++ b/aes/aes.go
@@ -21,7 +21,8 @@ func initialize() {
 	if hd != nil {
 		return
 	}
-	hashids.NewData()
+
+	hd = hashids.NewData()
 	salt = os.Getenv("AES_KEY")
 	minLengthStr := os.Getenv("AES_MIN_LENGTH")
 

--- a/aes/aes.go
+++ b/aes/aes.go
@@ -1,21 +1,40 @@
 package aes
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"strconv"
 
-	"github.com/joho/godotenv"
 	"github.com/speps/go-hashids"
 )
 
-var _ = godotenv.Load()
-var hd = hashids.NewData()
-var salt = os.Getenv("AES_KEY")
-var minLength, _ = strconv.Atoi(os.Getenv("AES_MIN_LENGTH"))
+var hd *hashids.HashIDData
+var salt string
+var minLength int
+
+func initialize() {
+	if hd != nil {
+		return
+	}
+	hashids.NewData()
+	salt = os.Getenv("AES_KEY")
+	minLengthStr := os.Getenv("AES_MIN_LENGTH")
+
+	if salt == "" || minLengthStr == "" {
+		log.Println("aes: env not found: AES_KEY or AES_MIN_LENGTH")
+	}
+
+	minLength, _ = strconv.Atoi(minLengthStr)
+}
 
 // Encrypt Function
 func Encrypt(id int) string {
+	initialize()
 	hd.Salt = salt
 	hd.MinLength = minLength
 	h, _ := hashids.NewWithData(hd)
@@ -25,6 +44,7 @@ func Encrypt(id int) string {
 
 // Decrypt Function
 func Decrypt(data string) int {
+	initialize()
 	hd.Salt = salt
 	hd.MinLength = minLength
 	h, _ := hashids.NewWithData(hd)
@@ -55,4 +75,39 @@ func EncryptBulk(data []int) (ret []string) {
 		ret[i] = Encrypt(data[i])
 	}
 	return ret
+}
+
+// EncryptString ...
+func EncryptString(data []byte) ([]byte, error) {
+	block, _ := aes.NewCipher([]byte(os.Getenv("AES_STRING_KEY")))
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	ciphertext := gcm.Seal(nonce, nonce, data, nil)
+	return ciphertext, nil
+}
+
+// DecryptString ...
+func DecryptString(data []byte) ([]byte, error) {
+	key := []byte(os.Getenv("AES_STRING_KEY"))
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := gcm.NonceSize()
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+	return plaintext, nil
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,10 +3,7 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
-	"reflect"
-	"strings"
 	"time"
 
 	"github.com/go-redis/redis"
@@ -159,113 +156,4 @@ func TTL(key string) (float64, error) {
 		return 0, fmt.Errorf("ttl: set duration failed: %s: %s", os.Getenv("REDIS_HOST"), err.Error())
 	}
 	return res, nil
-}
-
-func getKey(data interface{}) (key string, err error) {
-	v := reflect.ValueOf(data)
-
-	// check for nil and pointer dereference
-	if data == nil {
-		return
-	}
-	if v.Kind() == reflect.Ptr {
-		if v.IsNil() {
-			return
-		}
-		v = v.Elem()
-	}
-
-	t := v.Type()
-
-	for i := 0; i < v.NumField(); i++ {
-		field := v.Field(i)
-		fieldT := t.Field(i)
-
-		// check tag exist
-		cacheTag := fieldT.Tag.Get("cache")
-		if len(cacheTag) == 0 {
-			continue
-		}
-		tags := strings.Split(cacheTag, ",")
-
-		// check empty value
-		if tags[0] != "optional" && reflect.DeepEqual(field.Interface(), reflect.Zero(fieldT.Type).Interface()) {
-			return "", fmt.Errorf("redis key: data cannot be empty")
-		}
-
-		// get json tag, else name
-		name := strings.SplitN(fieldT.Tag.Get("json"), ",", 2)[0]
-		if name == "" || name == "-" {
-			name = strings.ToLower(fieldT.Name)
-		}
-
-		// pointer dereference
-		if field.Kind() == reflect.Ptr {
-			field = v.Elem()
-		}
-
-		value := field.Interface()
-
-		// if nested struct
-		if tags[0] != "nodive" {
-			if field.Kind() == reflect.Struct {
-				value, err = getKey(value)
-				if err != nil {
-					return "", err
-				}
-			}
-		}
-
-		key = fmt.Sprintf("%v#%v:%v", key, name, value)
-	}
-	return key, nil
-}
-
-// Key params
-// @data: interface{}
-// @prefixes: ...string
-// return string, error
-func Key(data interface{}, prefixes ...string) (key string) {
-	v := reflect.ValueOf(data)
-	serviceName := os.Getenv("SERVICE_NAME")
-
-	if serviceName == "" {
-		log.Println("redis key: SERVICE_NAME env variable should not be empty")
-		return ""
-	}
-
-	// for non struct based key
-	if data == nil {
-		key = serviceName
-
-		for _, p := range prefixes {
-			key = fmt.Sprintf("%v#%v", key, p)
-		}
-		return key
-	}
-
-	if reflect.DeepEqual(data, reflect.Zero(reflect.TypeOf(data)).Interface()) {
-		log.Println("redis key: data should not be empty")
-		return ""
-	}
-
-	// pointer dereference
-	if v.Kind() == reflect.Ptr {
-		v = v.Elem()
-	}
-
-	key = fmt.Sprintf("%v#%v", serviceName, v.Type().Name())
-
-	for _, p := range prefixes {
-		key = fmt.Sprintf("%v#%v", key, p)
-	}
-
-	dataKey, err := getKey(data)
-	if err != nil {
-		log.Println(err.Error())
-		return ""
-	}
-	key += dataKey
-
-	return key
 }

--- a/cache/key.go
+++ b/cache/key.go
@@ -57,12 +57,14 @@ func getKey(data interface{}) (key string, err error) {
 		value := field.Interface()
 
 		// if nested struct
-		if tags[0] != "nodive" {
-			if field.Kind() == reflect.Struct {
+		if field.Kind() == reflect.Struct {
+			if tags[0] != "nodive" {
 				value, err = getKey(value)
 				if err != nil {
 					return "", err
 				}
+			} else if tags[1] != "key" {
+				continue
 			}
 		}
 

--- a/cache/key.go
+++ b/cache/key.go
@@ -36,7 +36,10 @@ func getKey(data interface{}) (key string, err error) {
 		tags := strings.Split(cacheTag, ",")
 
 		// check empty value
-		if tags[0] != "optional" && reflect.DeepEqual(field.Interface(), reflect.Zero(fieldT.Type).Interface()) {
+		if reflect.DeepEqual(field.Interface(), reflect.Zero(fieldT.Type).Interface()) {
+			if tags[0] == "optional" {
+				continue
+			}
 			return "", fmt.Errorf("redis key: data cannot be empty")
 		}
 

--- a/cache/key.go
+++ b/cache/key.go
@@ -1,0 +1,139 @@
+package cache
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"strings"
+)
+
+func getKey(data interface{}) (key string, err error) {
+	v := reflect.ValueOf(data)
+
+	// check for nil and pointer dereference
+	if data == nil {
+		return
+	}
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return
+		}
+		v = v.Elem()
+	}
+
+	t := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		fieldT := t.Field(i)
+
+		// check tag exist
+		cacheTag := fieldT.Tag.Get("cache")
+		if len(cacheTag) == 0 {
+			continue
+		}
+		tags := strings.Split(cacheTag, ",")
+
+		// check empty value
+		if tags[0] != "optional" && reflect.DeepEqual(field.Interface(), reflect.Zero(fieldT.Type).Interface()) {
+			return "", fmt.Errorf("redis key: data cannot be empty")
+		}
+
+		// get json tag, else name
+		name := strings.SplitN(fieldT.Tag.Get("json"), ",", 2)[0]
+		if name == "" || name == "-" {
+			name = strings.ToLower(fieldT.Name)
+		}
+
+		// pointer dereference
+		if field.Kind() == reflect.Ptr {
+			field = v.Elem()
+		}
+
+		value := field.Interface()
+
+		// if nested struct
+		if tags[0] != "nodive" {
+			if field.Kind() == reflect.Struct {
+				value, err = getKey(value)
+				if err != nil {
+					return "", err
+				}
+			}
+		}
+
+		key = fmt.Sprintf("%v#%v:%v", key, name, value)
+	}
+	return key, nil
+}
+
+func key(serviceName string, data interface{}, prefixes ...string) (key string, err error) {
+	v := reflect.ValueOf(data)
+
+	// for non struct based key
+	if data == nil {
+		key = serviceName
+
+		for _, p := range prefixes {
+			key = fmt.Sprintf("%v#%v", key, p)
+		}
+		return key, nil
+	}
+
+	if reflect.DeepEqual(data, reflect.Zero(reflect.TypeOf(data)).Interface()) {
+		return "", fmt.Errorf("redis key: data should not be empty")
+	}
+
+	// pointer dereference
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	key = fmt.Sprintf("%v#%v", serviceName, v.Type().Name())
+
+	for _, p := range prefixes {
+		key = fmt.Sprintf("%v#%v", key, p)
+	}
+
+	dataKey, err := getKey(data)
+	if err != nil {
+		return "", fmt.Errorf(err.Error())
+	}
+	key += dataKey
+
+	return key, nil
+}
+
+// Key params
+// @data: interface{}
+// @prefixes: ...string
+// return string, error
+func Key(data interface{}, prefixes ...string) string {
+	serviceName := os.Getenv("SERVICE_NAME")
+	if serviceName == "" {
+		log.Println("redis key: SERVICE_NAME env variable should not be empty")
+		return ""
+	}
+
+	key, err := key(serviceName, data, prefixes...)
+	if err != nil {
+		log.Println(err.Error())
+		return ""
+	}
+	return key
+}
+
+// ExternalKey params
+// @serviceName: string
+// @data: interface{}
+// @prefixes: ...string
+// return string, error
+func ExternalKey(serviceName string, data interface{}, prefixes ...string) string {
+	key, err := key(serviceName, data, prefixes...)
+	if err != nil {
+		log.Println(err.Error())
+		return ""
+	}
+	return key
+}

--- a/cache/key.go
+++ b/cache/key.go
@@ -90,6 +90,10 @@ func key(serviceName string, data interface{}, prefixes ...string) (key string, 
 		v = v.Elem()
 	}
 
+	if v.Kind() != reflect.Struct {
+		return "", fmt.Errorf("redis key: data should be a struct")
+	}
+
 	key = fmt.Sprintf("%v#%v", serviceName, v.Type().Name())
 
 	for _, p := range prefixes {

--- a/rest/pagination/pagination.go
+++ b/rest/pagination/pagination.go
@@ -1,0 +1,20 @@
+package pagination
+
+// Pagination scheme
+type Pagination struct {
+	Limit  int `form:"limit"`
+	Page   int `form:"page"`
+	Offset int
+}
+
+// Paginate params
+func (pagination *Pagination) Paginate() {
+	if pagination.Limit == 0 || pagination.Limit < 1 {
+		pagination.Limit = 10
+	}
+	if pagination.Page == 0 || pagination.Page < 1 {
+		pagination.Page = 1
+	}
+
+	pagination.Offset = (pagination.Page - 1) * pagination.Limit
+}

--- a/rest/pagination/pagination.go
+++ b/rest/pagination/pagination.go
@@ -2,8 +2,8 @@ package pagination
 
 // Pagination scheme
 type Pagination struct {
-	Limit  int `form:"limit"`
-	Page   int `form:"page"`
+	Limit  int `form:"limit" cache:"key"`
+	Page   int `form:"page" cache:"key"`
 	Offset int
 }
 

--- a/rest/restid/restid.go
+++ b/rest/restid/restid.go
@@ -12,7 +12,7 @@ import (
 // ID type for database/json id handling
 type ID struct {
 	Raw       uint
-	Encrypted string
+	Encrypted string `cache:"key"`
 	Valid     bool
 }
 


### PR DESCRIPTION
# Redis Key
- no longer returns error, prints warning instead
- no longer requires dive for structs to allow embedded struct. use "nodive" tag to avoid diving instead
- add warning when data is not struct
- allows optional fields when using "optional" tag
- added ExternalKey function for different service

# AES
- use "singleton" to avoid loading env (needed for unit testing)
- added encrypt/decrypt string (used in service/consumer payment)

# REST
- added pagination struct and helper
- restid added redis key functionality