### PR TITLE
[HDS-64] Update Maximum Limit Behavior; Test;

### DIFF
--- a/v1/pagination/pagination.go
+++ b/v1/pagination/pagination.go
@@ -9,7 +9,7 @@ type Paginator interface {
 const (
 	DefaultPage  = 1
 	DefaultLimit = 10
-	MaximumLimit = 100
+	MaximumLimit = 250
 )
 
 // Paginate params
@@ -25,8 +25,11 @@ func (p *Pagination) SetToDefault() {
 
 // ValidatePagination will validate pagination's value
 func (p *Pagination) ValidatePagination() {
-	if p.Page < 1 || p.Limit < 1 || p.Limit > MaximumLimit {
+	if p.Page < 1 || p.Limit < 1 {
 		p.SetToDefault()
+	}
+	if p.Limit > MaximumLimit {
+		p.Limit = MaximumLimit
 	}
 }
 

--- a/v1/pagination/pagination.go
+++ b/v1/pagination/pagination.go
@@ -9,7 +9,7 @@ type Paginator interface {
 const (
 	DefaultPage  = 1
 	DefaultLimit = 10
-	MaximumLimit = 250
+	MaximumLimit = 100
 )
 
 // Paginate params

--- a/v1/pagination/pagination_test.go
+++ b/v1/pagination/pagination_test.go
@@ -73,8 +73,8 @@ var (
 			name:          "Test Case 4",
 			argsPage:      2,
 			argsLimit:     2000,
-			expectedPage:  page.DefaultPage,
-			expectedLimit: page.DefaultLimit,
+			expectedPage:  2,
+			expectedLimit: page.MaximumLimit,
 		},
 		{
 			name:          "Test Case 5",
@@ -89,6 +89,13 @@ var (
 			argsLimit:     -1000,
 			expectedPage:  page.DefaultPage,
 			expectedLimit: page.DefaultLimit,
+		},
+		{
+			name:          "Test Case 7",
+			argsPage:      1,
+			argsLimit:     250,
+			expectedPage:  1,
+			expectedLimit: page.MaximumLimit,
 		},
 	}
 
@@ -139,7 +146,7 @@ var (
 			name:           "Test Case 7",
 			argsPage:       7,
 			argsLimit:      1000,
-			expectedOffset: 0,
+			expectedOffset: page.MaximumLimit * 6,
 		},
 	}
 
@@ -210,8 +217,8 @@ func TestValidatePagination(t *testing.T) {
 		pageObj.ValidatePagination()
 
 		// Assert result based on test case
-		assert.Equal(t, pageObj.Page, test.expectedPage, fmt.Sprintf("Unexpected page value on %s", test.name))
-		assert.Equal(t, pageObj.Limit, test.expectedLimit, fmt.Sprintf("Unexpected limit value on %s", test.name))
+		assert.Equal(t, test.expectedPage, pageObj.Page, fmt.Sprintf("Unexpected page value on %s", test.name))
+		assert.Equal(t, test.expectedLimit, pageObj.Limit, fmt.Sprintf("Unexpected limit value on %s", test.name))
 	}
 }
 
@@ -226,7 +233,7 @@ func TestPaginate(t *testing.T) {
 		pageObj.Paginate()
 
 		// Assert result based on test case
-		assert.Equal(t, pageObj.Offset, test.expectedOffset, fmt.Sprintf("Unexpected offset value on %s", test.name))
+		assert.Equal(t, test.expectedOffset, pageObj.Offset, fmt.Sprintf("Unexpected offset value on %s", test.name))
 	}
 }
 
@@ -241,8 +248,8 @@ func TestSetTotalPage(t *testing.T) {
 		pageObj.SetTotalPage()
 
 		// Assert result based on test case
-		assert.Equal(t, pageObj.Limit, test.expectedLimit, fmt.Sprintf("Unexpected limit value on %s", test.name))
-		assert.Equal(t, pageObj.TotalPage, test.expectedTotalPage, fmt.Sprintf("Unexpected total page value on %s", test.name))
+		assert.Equal(t, test.expectedLimit, pageObj.Limit, fmt.Sprintf("Unexpected limit value on %s", test.name))
+		assert.Equal(t, test.expectedTotalPage, pageObj.TotalPage, fmt.Sprintf("Unexpected total page value on %s", test.name))
 	}
 }
 

--- a/v1/pagination/pagination_test.go
+++ b/v1/pagination/pagination_test.go
@@ -93,7 +93,7 @@ var (
 		{
 			name:          "Test Case 7",
 			argsPage:      1,
-			argsLimit:     250,
+			argsLimit:     100,
 			expectedPage:  1,
 			expectedLimit: page.MaximumLimit,
 		},


### PR DESCRIPTION
## Description

> Please add your task in ClickUp here.

[HDS-64](https://app.clickup.com/t/3857515/HDS-64)

## What's new?

> Please add if you added new improvement
- Set Limit request to `MaximumLimit` if `limit > 100`, with the same page.
    - Previously Set to Default Page 1 & Limit 10 when Limit is more than MaximumLimit.
- `assert.Equal` confused expected & actual.
![image](https://user-images.githubusercontent.com/33178140/113967287-ddc3b000-985a-11eb-9d2f-0c102c1b3398.png)
![Screenshot_20210408-113207_Samsung Internet](https://user-images.githubusercontent.com/33178140/113968835-17e28100-985e-11eb-959d-c0276221199c.jpg)
