### PR TITLE
[AI-60] Debug go-utils Publisher for AI

### DIFF
--- a/v1/rabbitmq/publisher/v1/exchange.go
+++ b/v1/rabbitmq/publisher/v1/exchange.go
@@ -69,6 +69,17 @@ func (route *Route) Publish(publish *Publish) error {
 		return err
 	}
 
+	err = channel.QueueBind(
+		route.QueueName,	// queue name
+		route.RoutingKey,	// routing key
+		route.ExchangeName, // exchange
+		false,				// no-wait
+		nil,				// arguments
+	)
+	if err != nil {
+		log.Println(fmt.Sprintf("%s: %s", "Failed to bind a queue", err.Error()))
+	}
+
 	err = channel.Publish(
 		route.ExchangeName, // exchange name
 		route.RoutingKey,   // Routing key

--- a/v1/rest/rest.go
+++ b/v1/rest/rest.go
@@ -79,7 +79,7 @@ func ResponseData(context *gin.Context, status int, payload interface{}, msg ...
 	}
 
 	var copied gin.Context = *context
-	go PublishLog(&copied, status, payload, msg[0])
+	PublishLog(&copied, status, payload, msg[0])
 	context.JSON(status, response)
 	return ResponseResult{context, uuid.GetUUID()}
 }
@@ -111,7 +111,7 @@ func ResponseMessage(context *gin.Context, status int, msg ...string) ResponseRe
 	}
 	
 	var copied gin.Context = *context
-	go PublishLog(&copied, status, nil, msg[0])
+	PublishLog(&copied, status, nil, msg[0])
 	context.JSON(status, response)
 	return ResponseResult{context, response.Error}
 }

--- a/v1/rest/rest.go
+++ b/v1/rest/rest.go
@@ -245,6 +245,7 @@ func PublishLog(context *gin.Context, status int, payload interface{}, msg ...st
 
 	utcTime := time.Now().In(location).Format(time.RFC3339Nano)
 	data, err := json.Marshal(map[string]interface{}{
+		"SERVICE_NAME": os.Getenv("SERVICE_NAME"),
 		"payload": body,
 		"timestamp": utcTime,
 	})

--- a/v1/rest/rest.go
+++ b/v1/rest/rest.go
@@ -245,7 +245,7 @@ func PublishLog(context *gin.Context, status int, payload interface{}, msg ...st
 
 	utcTime := time.Now().In(location).Format(time.RFC3339Nano)
 	data, err := json.Marshal(map[string]interface{}{
-		"SERVICE_NAME": os.Getenv("SERVICE_NAME"),
+		"service_name": os.Getenv("SERVICE_NAME"),
 		"payload": body,
 		"timestamp": utcTime,
 	})


### PR DESCRIPTION
## Description

> Please add your task in ClickUp here.

Task: [[AI-60] Debug go-utils Publisher for AI](https://app.clickup.com/t/3857515/AI-60)

## What's new?

> Please add if you added new improvement

- Add "SERVICE_NAME" key to publish for logging
- Add QueueBind in `exchange.go`
- Remove go routine when `PublishLog()`, because `context.Request.Body` cannot be accessed after `context.JSON()`