### PR TITLE
Fix Return AccessToken Expired when No Auth is Present

### DIFF
--- a/v1/middleware/auth.go
+++ b/v1/middleware/auth.go
@@ -67,6 +67,7 @@ func (mid *Middleware) Auth(ctx *gin.Context) {
 
 	id, err := jwt.ExtractID(auth)
 	if err != nil {
+		log.Println("extract id: " + err.Error())
 		rest.ResponseError(ctx, http.StatusUnauthorized, map[string]string{
 			"access_token": "expired",
 		})
@@ -76,8 +77,8 @@ func (mid *Middleware) Auth(ctx *gin.Context) {
 
 	status, err := GetStatus(ctx, mid.elastic, id)
 	if err != nil {
-		rest.ResponseMessage(ctx, http.StatusInternalServerError).
-			Log("auth: " + err.Error())
+		log.Println("get status: " + err.Error())
+		rest.ResponseMessage(ctx, http.StatusInternalServerError)
 		ctx.Abort()
 		return
 	}

--- a/v1/middleware/auth.go
+++ b/v1/middleware/auth.go
@@ -58,7 +58,14 @@ func GetStatus(ctx *gin.Context, es *elastic.Client, memberID int) (status Membe
 }
 
 func (mid *Middleware) Auth(ctx *gin.Context) {
-	id, err := jwt.ExtractID(ctx.GetHeader("Authorization"))
+	auth := ctx.GetHeader("Authorization")
+	if auth == "" {
+		rest.ResponseMessage(ctx, http.StatusUnauthorized)
+		ctx.Abort()
+		return
+	}
+
+	id, err := jwt.ExtractID(auth)
 	if err != nil {
 		rest.ResponseError(ctx, http.StatusUnauthorized, map[string]string{
 			"access_token": "expired",


### PR DESCRIPTION
Fix: Now empty authorization header will not return error message with detail that token is expired

![image](https://user-images.githubusercontent.com/51283152/141753121-59d586cf-5441-40b4-9f7d-e696bf919885.png)