### PR TITLE
fix: cache deleted before suspend ends

### DIFF
--- a/v1/middleware/auth.go
+++ b/v1/middleware/auth.go
@@ -40,7 +40,7 @@ func GetStatus(ctx *gin.Context, es *elastic.Client, memberID int) (status Membe
 	if isAlive {
 		err = cache.GetUnmarshal(statusKey, &status)
 		if err == nil {
-			if status.SuspendEnd != nil && status.SuspendEnd.After(time.Now().Add(5*time.Minute)) {
+			if status.SuspendEnd != nil && status.SuspendEnd.After(time.Now().Add(10*time.Minute)) {
 				suspendEnd := time.Until(*status.SuspendEnd)
 				cache.SetExpire(statusKey, int(suspendEnd.Seconds()))
 			} else {


### PR DESCRIPTION
Original flow will always set the expiry time to 10 minutes, but this becomes a problem if the user is actually suspended for more than 10 minutes: the cache will be cleared before the `SuspendEnd` time is reached.

This enhancement will set the cache expiry time to the original suspend duration with lower bound of 10 minutes (if suspension ends in 3 minutes, the cache will still live for another 10 minutes).