### PR TITLE
Feat nsqd http semaphore pub

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,22 +1,56 @@
 module github.com/forkyid/go-utils
 
-go 1.16
+go 1.21.0
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/gin-gonic/gin v1.7.4
+	github.com/gin-gonic/gin v1.10.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
-	github.com/go-playground/validator/v10 v10.4.1
+	github.com/go-playground/validator/v10 v10.22.1
 	github.com/go-redis/redis v6.15.9+incompatible
-	github.com/google/uuid v1.1.2
-	github.com/nsqio/go-nsq v1.0.8
-	github.com/olivere/elastic/v7 v7.0.22
+	github.com/google/uuid v1.6.0
+	github.com/nsqio/go-nsq v1.1.0
+	github.com/olivere/elastic/v7 v7.0.32
+	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.9.3
+	github.com/speps/go-hashids v2.0.0+incompatible
+	github.com/streadway/amqp v1.1.0
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/sync v0.8.0
+)
+
+require (
+	github.com/bytedance/sonic v1.12.3 // indirect
+	github.com/bytedance/sonic/loader v0.2.0 // indirect
+	github.com/cloudwego/base64x v0.1.4 // indirect
+	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/goccy/go-json v0.10.3 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.8 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/onsi/ginkgo v1.14.2 // indirect
 	github.com/onsi/gomega v1.10.3 // indirect
-	github.com/pkg/errors v0.9.1
-	github.com/sirupsen/logrus v1.8.1
-	github.com/speps/go-hashids v2.0.0+incompatible
-	github.com/streadway/amqp v1.0.0
-	github.com/stretchr/testify v1.6.1
-	golang.org/x/sync v0.8.0
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ugorji/go/codec v1.2.12 // indirect
+	golang.org/x/arch v0.11.0 // indirect
+	golang.org/x/crypto v0.28.0 // indirect
+	golang.org/x/net v0.30.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+	golang.org/x/text v0.19.0 // indirect
+	google.golang.org/protobuf v1.35.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,5 @@ require (
 	github.com/speps/go-hashids v2.0.0+incompatible
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sync v0.8.0
 )

--- a/v1/nsq/publisher/v1/producer.go
+++ b/v1/nsq/publisher/v1/producer.go
@@ -50,11 +50,11 @@ func pubTypeHTTPS(topic string, data []byte) (err error) {
 	pubPool := connection.StartProducerPool()
 	ctx := context.Background()
 	pubPool.Acquire(ctx, 1)
-	go pubishHTTPS(data, topic, pubPool)
+	go publishHTTPS(data, topic, pubPool)
 	return
 }
 
-func pubishHTTPS(data []byte, topic string, pool *semaphore.Weighted) {
+func publishHTTPS(data []byte, topic string, pool *semaphore.Weighted) {
 	pubRetry := retry
 	host := fmt.Sprintf("%s/pub?topic=%s", os.Getenv("NSQD_HOST"), topic)
 	defer pool.Release(1)

--- a/v1/nsq/publisher/v1/producer.go
+++ b/v1/nsq/publisher/v1/producer.go
@@ -1,24 +1,77 @@
 package v1
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"log"
+	"net/http"
 	"os"
 
 	connection "github.com/forkyid/go-utils/v1/nsq"
+	"golang.org/x/sync/semaphore"
 )
 
-func Publish(data []byte) error {
+const (
+	PubTypeNSQD  = "nsqd"
+	PubTypeHTTPS = "https"
+	retry        = 3
+)
+
+func Publish(data []byte) (err error) {
+	publishType := os.Getenv("NSQD_PUB_TYPE")
+	topic := os.Getenv("NSQD_TOPIC")
+
+	switch publishType {
+	case PubTypeHTTPS:
+		err = pubTypeHTTPS(topic, data)
+	default:
+		err = pubTypeNSQD(topic, data)
+	}
+	return
+}
+
+func pubTypeNSQD(topic string, data []byte) (err error) {
 	producer, err := connection.Start()
 	if err != nil {
 		log.Println("failed to connect to nsqd: ", err.Error())
-		return err
+		return
 	}
 
-	err = producer.PublishAsync(os.Getenv("NSQD_TOPIC"), data, nil)
+	err = producer.PublishAsync(topic, data, nil)
 	if err != nil {
 		log.Println("failed to publish data to nsqd: ", err.Error())
-		return err
+		return
 	}
+	return
+}
 
-	return err
+func pubTypeHTTPS(topic string, data []byte) (err error) {
+	pubPool := connection.StartProducerPool()
+	ctx := context.Background()
+	pubPool.Acquire(ctx, 1)
+	go pubishHTTPS(data, topic, pubPool)
+	return
+}
+
+func pubishHTTPS(data []byte, topic string, pool *semaphore.Weighted) {
+	pubRetry := retry
+	host := fmt.Sprintf("%s/pub?topic=%s", os.Getenv("NSQD_HOST"), topic)
+	defer pool.Release(1)
+	req, _ := http.NewRequest(
+		http.MethodPost,
+		host,
+		bytes.NewReader(data),
+	)
+	client := &http.Client{}
+retPub:
+	pubRetry--
+	resp, err := client.Do(req)
+	if resp.StatusCode != http.StatusOK || err != nil {
+		if retry < 0 {
+			log.Printf("[ERROR] [%d] [%s] %v", resp.StatusCode, host, string(data))
+			return
+		}
+		goto retPub
+	}
 }

--- a/v1/nsq/publisher/v1/producer.go
+++ b/v1/nsq/publisher/v1/producer.go
@@ -51,7 +51,10 @@ func pubTypeNSQD(topic string, data []byte) (err error) {
 func pubTypeHTTPS(topic string, data []byte) (err error) {
 	pubPool := connection.StartProducerPool()
 	ctx := context.Background()
-	pubPool.Acquire(ctx, 1)
+	err = pubPool.Acquire(ctx, 1)
+	if err != nil {
+		return
+	}
 	go func() {
 		defer pubPool.Release(1)
 		publishHTTPS(data, topic)

--- a/v1/nsq/publisher/v1/producer.go
+++ b/v1/nsq/publisher/v1/producer.go
@@ -67,7 +67,14 @@ func publishHTTPS(data []byte, topic string, pool *semaphore.Weighted) {
 retPub:
 	pubRetry--
 	resp, err := client.Do(req)
-	if resp.StatusCode != http.StatusOK || err != nil {
+	if err != nil {
+		if retry < 0 {
+			log.Printf("[ERROR] [%d] [%s] %v \n", resp.StatusCode, host, string(data))
+			return
+		}
+		goto retPub
+	}
+	if resp.StatusCode != http.StatusOK {
 		if retry < 0 {
 			log.Printf("[ERROR] [%d] [%s] %v", resp.StatusCode, host, string(data))
 			return

--- a/v1/nsq/publisher/v1/producer.go
+++ b/v1/nsq/publisher/v1/producer.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	connection "github.com/forkyid/go-utils/v1/nsq"
 	"golang.org/x/sync/semaphore"
@@ -68,17 +69,19 @@ retPub:
 	pubRetry--
 	resp, err := client.Do(req)
 	if err != nil {
-		if retry < 0 {
-			log.Printf("[ERROR] [%d] [%s] %v \n", resp.StatusCode, host, string(data))
+		if pubRetry < 0 {
+			log.Printf("[ERROR] [%s] [%s] %v \n", host, err.Error(), string(data))
 			return
 		}
+		time.Sleep(3 * time.Second)
 		goto retPub
 	}
 	if resp.StatusCode != http.StatusOK {
-		if retry < 0 {
+		if pubRetry < 0 {
 			log.Printf("[ERROR] [%d] [%s] %v", resp.StatusCode, host, string(data))
 			return
 		}
+		time.Sleep(3 * time.Second)
 		goto retPub
 	}
 }

--- a/v1/rest/rest.go
+++ b/v1/rest/rest.go
@@ -238,10 +238,11 @@ func GetData(jsonBody []byte) (json.RawMessage, error) {
 }
 
 // PublishLog params
-// 	@context: *gin.Context
-// 	@status: int
-// 	@payload: interface
-// 	@msg: []string
+//
+//	@context: *gin.Context
+//	@status: int
+//	@payload: interface
+//	@msg: []string
 //	@return error
 func PublishLog(context *gin.Context, status int, payload interface{}, msg ...string) error {
 	requestBody, err := ioutil.ReadAll(context.Request.Body)


### PR DESCRIPTION
env notes
```env

# https / nsqd
NSQD_PUB_TYPE=

# semaphore pool size
NSQD_POOL_SIZE=
```
- [Semaphore Explanation](https://blog.stackademic.com/go-concurrency-visually-explained-semaphore-3ffe23f11388)

Benchmark
---
Pub 100.000 msg
Proc: 8 core
- Pool 1: 3m35.136727452s
- Pool 2: 2m3.10689509s
- Pool 4: 1m23.771196907s
- Pool 5: 1m14.738611515s
- Pool 8: 1m12.991400737s
