### PR TITLE
Remove Ban and Suspend Checking from Middleware

### DIFF
--- a/v1/aes/aes.go
+++ b/v1/aes/aes.go
@@ -63,7 +63,6 @@ func Decrypt(data string) int {
 
 // DecryptBulk Function
 func DecryptBulk(data []string) (ret []int, err error) {
-	ret = make([]int, len(data))
 	for i := range data {
 		decrypted := Decrypt(data[i])
 		if decrypted <= 0 {


### PR DESCRIPTION
## Changes

- Remove function Get Ban Status and Get Suspend Status

## Removed from ENV
```
GET_BAN_STATUS_SERVICE_NAME=
GET_BAN_STATUS_FALLBACK_BASE_URL=
GET_BAN_STATUS_PATH=
GET_BAN_STATUS_BASIC_AUTH_USERNAME=
GET_BAN_STATUS_BASIC_AUTH_PASSWORD=

GET_SUSPEND_STATUS_SERVICE_NAME=
GET_SUSPEND_STATUS_FALLBACK_BASE_URL=
GET_SUSPEND_STATUS_PATH=
GET_SUSPEND_STATUS_BASIC_AUTH_USERNAME=
GET_SUSPEND_STATUS_BASIC_AUTH_PASSWORD=
```