### PR TITLE
Standard Golang Context for Cancellation Propagation

### DIFF
--- a/v1/middleware/auth.go
+++ b/v1/middleware/auth.go
@@ -58,7 +58,7 @@ func checkAuthToken(ctx *gin.Context, bearerToken string) (resp rest.Response, e
 		Body: bytes.NewReader(payloadJson),
 	}
 
-	respJson, statusCode := req.Send()
+	respJson, statusCode := req.SendWithContext(ctx)
 	err = errors.Wrap(json.Unmarshal(respJson, &resp), "unmarshal ")
 	resp.Status = statusCode
 
@@ -159,7 +159,7 @@ func getAccStatus(ctx *gin.Context) (isOnHold bool, err error) {
 			"Authorization": ctx.GetHeader("Authorization")},
 	}
 
-	respJson, code := req.Send()
+	respJson, code := req.SendWithContext(ctx)
 	if code != http.StatusOK {
 		err = fmt.Errorf("[%v] %v: %v", req.Method, req.URL, string(respJson))
 		return
@@ -198,7 +198,7 @@ func getAgeGroup(ctx *gin.Context) (encAgeGroupID string, err error) {
 			"Authorization": ctx.GetHeader("Authorization")},
 	}
 
-	respJson, code := req.Send()
+	respJson, code := req.SendWithContext(ctx)
 	if code != http.StatusOK {
 		err = fmt.Errorf("[%v] %v: %v", req.Method, req.URL, string(respJson))
 		return

--- a/v1/middleware/featureflagstatus.go
+++ b/v1/middleware/featureflagstatus.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -25,7 +26,7 @@ type FeatureFlagStatus struct {
 // CheckFeatureFlagStatus checks feature flag status by key and abort if status is not enabled.
 func (mid *Middleware) CheckFeatureFlagStatus(key string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		status, err := getFeatureFlagStatus(key)
+		status, err := getFeatureFlagStatus(ctx, key)
 		if err != nil {
 			rest.ResponseMessage(ctx, http.StatusInternalServerError).Log("get feature flag status", err)
 			ctx.Abort()
@@ -48,13 +49,13 @@ func (mid *Middleware) CheckFeatureFlagStatus(key string) gin.HandlerFunc {
 }
 
 // getFeatureFlagStatus gets feature flag status by its key.
-func getFeatureFlagStatus(key string) (status FeatureFlagStatus, err error) {
+func getFeatureFlagStatus(ctx context.Context, key string) (status FeatureFlagStatus, err error) {
 	req := rest.Request{
 		URL:    fmt.Sprintf("%v/flag/v1/check?key=%v", os.Getenv("API_ORIGIN_URL"), key),
 		Method: http.MethodGet,
 	}
 
-	body, code := req.Send()
+	body, code := req.SendWithContext(ctx)
 	if code != http.StatusOK {
 		err = fmt.Errorf("[%v] %v: %v", req.Method, req.URL, string(body))
 		return

--- a/v1/rest/request.go
+++ b/v1/rest/request.go
@@ -40,8 +40,6 @@ func ValidMethod(method string) bool {
 	}
 }
 
-// Send docs
-//
 // Deprecated: use SendWithContext
 func (request *Request) Send() ([]byte, int) {
 	return request.SendWithContext(context.Background())

--- a/v1/rest/request.go
+++ b/v1/rest/request.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"log"
@@ -39,15 +40,20 @@ func ValidMethod(method string) bool {
 	}
 }
 
-// Send func
-// return []byte, int
+// Send docs
+//
+// Deprecated: use SendWithContext
 func (request *Request) Send() ([]byte, int) {
+	return request.SendWithContext(context.Background())
+}
+
+func (request *Request) SendWithContext(ctx context.Context) ([]byte, int) {
 	if !ValidMethod(request.Method) {
 		log.Println("[WARN] Unsupported method supplied, use one of constants provided by http package (e.g. http.MethodGet)")
 		return nil, -1
 	}
 
-	req, _ := http.NewRequest(request.Method, request.URL, request.Body)
+	req, _ := http.NewRequestWithContext(ctx, request.Method, request.URL, request.Body)
 
 	for k, v := range request.Headers {
 		req.Header.Set(k, v)


### PR DESCRIPTION
## Changes

- passing standard Golang `context.Context` for sending apicall request